### PR TITLE
Fixed could not find declaration file for powerups

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
       "import": "./dist/scrollbar.modern.js"
     },
     "./powerups": {
+      "types": "./dist/powerups/index.d.ts",
       "require": "./dist/powerups.cjs",
       "import": "./dist/powerups.modern.js"
     },


### PR DESCRIPTION
Fixed error:
Could not find a declaration file for module '@14islands/r3f-scroll-rig/powerups'.