### PR TITLE
fix: reload with scroll restoration (issue #44)

### DIFF
--- a/powerups/StickyScrollScene.tsx
+++ b/powerups/StickyScrollScene.tsx
@@ -27,7 +27,7 @@ const StickyChild = ({
   useFrame((_, delta) => {
     if (!scrollState.inViewport) return
 
-    const topOffset = (childTop - offsetTop + initialScrollY) / size.height
+    const topOffset = (childTop - offsetTop + initialScrollY + 1) / size.height
     const bottomOffset = (childBottom / parentScale[1]) * scaleMultiplier
 
     //  move to top of sticky area

--- a/powerups/StickyScrollScene.tsx
+++ b/powerups/StickyScrollScene.tsx
@@ -22,11 +22,12 @@ const StickyChild = ({
 }: any) => {
   const group = useRef<Group>(null!)
   const size = useThree((s) => s.size)
+  const initialScrollY = useRef(window.scrollY || 0).current;
 
   useFrame((_, delta) => {
     if (!scrollState.inViewport) return
 
-    const topOffset = (childTop - offsetTop) / size.height
+    const topOffset = (childTop - offsetTop + initialScrollY) / size.height
     const bottomOffset = (childBottom / parentScale[1]) * scaleMultiplier
 
     //  move to top of sticky area


### PR DESCRIPTION
Hello! I also hit on the same thing flagged in [issue 44](https://github.com/14islands/r3f-scroll-rig/issues/44) today. I believe the fix is fairly straight forward - and the fix is to calculate the initial scroll and add this to the the `topOffset` calculation. 

I also found an off issue where the item would vanish when scrolled back up to the very top, some kind off-by-one error - this fix for that to simply add `+ 1` to the `topOffset` calculation.

[Loom Demo & Explaination →](https://www.loom.com/share/781aa7e0402840149d0ec1f0642b33b1)